### PR TITLE
feat: add icons page link to navigation

### DIFF
--- a/apps/docs/src/components/header-nav.tsx
+++ b/apps/docs/src/components/header-nav.tsx
@@ -11,6 +11,7 @@ import {
   ChatBubbleIcon,
   CheckmarkIcon,
   CommunityIcon,
+  ConfettiIcon,
   LongArrowUpRightIcon,
   PencilTextIcon,
   RoadMapIcon
@@ -156,6 +157,13 @@ const menuData: MenuItem[] = [
         path: "https://tailgrids.com/roadmap",
         desc: "Discover upcoming features and releases",
         icon: <RoadMapIcon className="size-6" />,
+        external: false
+      },
+      {
+        title: "Icons",
+        path: "https://tailgrids.com/icons",
+        desc: "Get started with our tailgrids free icons",
+        icon: <ConfettiIcon className="size-6" />,
         external: false
       },
       {

--- a/apps/docs/src/components/mobile-nav.tsx
+++ b/apps/docs/src/components/mobile-nav.tsx
@@ -19,7 +19,8 @@ import {
   CommunityIcon,
   ChatBubbleIcon,
   RoadMapIcon,
-  PencilTextIcon
+  PencilTextIcon,
+  ConfettiIcon
 } from "./ui/icons";
 
 interface SubMenuItem {
@@ -79,6 +80,13 @@ const mobileMenuData: MenuItem[] = [
         path: "https://tailgrids.com/roadmap",
         icon: <RoadMapIcon className="size-5" />,
         external: true
+      },
+      {
+        title: "Icons",
+        path: "https://tailgrids.com/icons",
+        desc: "Get started with our tailgrids free icons",
+        icon: <ConfettiIcon className="size-5" />,
+        external: false
       },
       {
         title: "Blog",


### PR DESCRIPTION
This PR adds a link to the Icons page (tailgrids.com/icons) in both the header and mobile navigation menus.