### PR TITLE
style: update sidebar title color in dark mode

### DIFF
--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -297,6 +297,10 @@ body {
   @apply text-base font-semibold text-[#374151];
 }
 
+#nd-sidebar p {
+  @apply dark:text-white;
+}
+
 /* Hide search from sidebar - keep it only in header */
 #nd-sidebar > div:first-of-type {
   /* styles here */


### PR DESCRIPTION
This PR updates the text color of paragraphs in the sidebar (#nd-sidebar p) to be white in dark mode for better visibility.