### PR TITLE
fix: fix layout shift for components with overflow hidden

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -45,6 +45,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
       className={`${dmSans.variable} ${geistMono.variable}`}
       suppressHydrationWarning
       data-theme="light"
+      style={{ scrollbarGutter: "stable" }}
     >
       <head>
         <script src="https://accounts.google.com/gsi/client" async defer />

--- a/apps/docs/src/components/preview/dialog/dialog-controlled-preview.tsx
+++ b/apps/docs/src/components/preview/dialog/dialog-controlled-preview.tsx
@@ -57,7 +57,10 @@ export default function DialogControlledPreview() {
 
       <Dialog isOpen={isOpen} onOpenChange={setIsOpen}>
         <DialogOverlay isDismissable>
-          <DialogContent className="max-w-md border-none p-0 shadow-2xl overflow-hidden">
+          <DialogContent
+            className="max-w-md border-none p-0 shadow-2xl overflow-hidden"
+            showCloseButton={false}
+          >
             {/* Header */}
             <div className="relative h-32 bg-linear-to-br from-indigo-600 via-purple-600 to-pink-500 p-6">
               <div className="absolute inset-0 bg-white/5 backdrop-blur-[2px]" />

--- a/apps/docs/src/registry/core/dialog.tsx
+++ b/apps/docs/src/registry/core/dialog.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/utils/cn";
 import { Close } from "@tailgrids/icons";
-import type { ComponentProps } from "react";
+import { type ComponentProps } from "react";
 import {
   Button as AriaButton,
   type ButtonProps as AriaButtonProps,


### PR DESCRIPTION
 - Fix layout shift for components with overflow hidden
 - Remove the close icon from the controlled dialog example