### PR TITLE
feat: add GitHub Actions workflow for docs deployment to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,5 @@
 name: Deploy Docs to Cloudflare Workers
 
-
 on:
   push:
     branches:
@@ -39,7 +38,7 @@ jobs:
         run: npm run build --workspace=@tailgrids/icons
 
       - name: Build docs
-        run: npm run build --workspace=docs
+        run: npm run build:cf --workspace=docs
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -88,17 +88,14 @@ jobs:
             const marker = '<!-- cf-workers-preview-comment -->';
 
             const body = `${marker}
-            ## Cloudflare Workers Preview Deployment
+            ## Cloudflare Workers Deployment
 
             | | |
             |---|---|
             | **Status** | ✅ Deployed |
-            | **Preview URL** | ${deploymentUrl ? `[${deploymentUrl}](${deploymentUrl})` : '⚠️ No preview URL available'} |
-            | **Latest Commit** | \`${shortSha}\` |
-            | **Updated (UTC)** | ${timestamp} |
-
-            ---
-            <sub>Deployed via Cloudflare Workers • ${shortSha}</sub>`;
+            | **Preview URL** | ${deploymentUrl || '⚠️ No preview URL available'} |
+            | **Latest Commit** | ${shortSha} |
+            | **Updated (UTC)** | ${timestamp} |`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,108 @@
+name: Deploy Docs to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: docs-deploy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy Docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --frozen-lockfile
+
+      - name: Build docs (with dependencies)
+        run: npx turbo build --filter=docs
+
+      # Production deploy (push to main)
+      - name: Deploy to Cloudflare Workers (Production)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: 'apps/docs'
+          command: deploy
+
+      # Preview deploy (PR to main)
+      - name: Upload Preview Version
+        if: github.event_name == 'pull_request'
+        id: preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: 'apps/docs'
+          command: versions upload
+
+      # Comment on PR with preview URL
+      - name: Comment Preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentUrl = '${{ steps.preview.outputs.deployment-url }}';
+            const commitSha = '${{ github.event.pull_request.head.sha }}';
+            const shortSha = commitSha.substring(0, 7);
+            const timestamp = new Date().toISOString();
+            const marker = '<!-- cf-workers-preview-comment -->';
+
+            const body = `${marker}
+            ## ⚡ Cloudflare Workers Preview Deployment
+
+            | | |
+            |---|---|
+            | **Status** | ✅ Deployed |
+            | **Preview URL** | ${deploymentUrl ? `[${deploymentUrl}](${deploymentUrl})` : '⚠️ No preview URL available'} |
+            | **Commit** | \`${shortSha}\` |
+            | **Updated** | ${timestamp} |
+
+            ---
+            <sub>Deployed via Cloudflare Workers • ${shortSha}</sub>`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,6 @@
 name: Deploy Docs to Cloudflare Workers
 
+
 on:
   push:
     branches:
@@ -34,9 +35,13 @@ jobs:
       - name: Install dependencies
         run: npm install --frozen-lockfile
 
-      - name: Build docs (with dependencies)
-        run: npx turbo build --filter=docs --ui=stream
+      - name: Build icons package
+        run: npm run build --workspace=@tailgrids/icons
+
+      - name: Build docs
+        run: npm run build --workspace=docs
         env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           NEXT_PUBLIC_MEILISEARCH_HOST: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_HOST }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,13 +29,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --frozen-lockfile
 
       - name: Build docs (with dependencies)
         run: npx turbo build --filter=docs --ui=stream
+        env:
+          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+          NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
+          NEXT_PUBLIC_MEILISEARCH_HOST: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_HOST }}
+          NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY }}
 
       # Production deploy (push to main)
       - name: Deploy to Cloudflare Workers (Production)
@@ -44,7 +49,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: 'apps/docs'
+          workingDirectory: "apps/docs"
           command: deploy
 
       # Preview deploy (PR to main)
@@ -55,7 +60,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: 'apps/docs'
+          workingDirectory: "apps/docs"
           command: versions upload
 
       # Comment on PR with preview URL

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,6 +55,11 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: "apps/docs"
           command: deploy
+          secrets: |
+            NEXT_PUBLIC_SITE_URL
+            NEXT_PUBLIC_GTM_ID
+            NEXT_PUBLIC_MEILISEARCH_HOST
+            NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY
 
       # Preview deploy (PR to main)
       - name: Upload Preview Version
@@ -66,6 +71,11 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: "apps/docs"
           command: versions upload
+          secrets: |
+            NEXT_PUBLIC_SITE_URL
+            NEXT_PUBLIC_GTM_ID
+            NEXT_PUBLIC_MEILISEARCH_HOST
+            NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY
 
       # Comment on PR with preview URL
       - name: Comment Preview URL on PR

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build docs
         run: npm run build:cf --workspace=docs
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
           NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
           NEXT_PUBLIC_MEILISEARCH_HOST: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_HOST }}
@@ -76,18 +75,27 @@ jobs:
             const deploymentUrl = '${{ steps.preview.outputs.deployment-url }}';
             const commitSha = '${{ github.event.pull_request.head.sha }}';
             const shortSha = commitSha.substring(0, 7);
-            const timestamp = new Date().toISOString();
+            const timestamp = new Date().toLocaleDateString('en-US', {
+              month: 'short', 
+              day: '2-digit', 
+              year: 'numeric', 
+              hour: '2-digit', 
+              minute: '2-digit', 
+              hour12: true, 
+              timeZone: 'UTC'
+            });
+
             const marker = '<!-- cf-workers-preview-comment -->';
 
             const body = `${marker}
-            ## ⚡ Cloudflare Workers Preview Deployment
+            ## Cloudflare Workers Preview Deployment
 
             | | |
             |---|---|
             | **Status** | ✅ Deployed |
             | **Preview URL** | ${deploymentUrl ? `[${deploymentUrl}](${deploymentUrl})` : '⚠️ No preview URL available'} |
-            | **Commit** | \`${shortSha}\` |
-            | **Updated** | ${timestamp} |
+            | **Latest Commit** | \`${shortSha}\` |
+            | **Updated (UTC)** | ${timestamp} |
 
             ---
             <sub>Deployed via Cloudflare Workers • ${shortSha}</sub>`;

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Build docs
         run: npm run build:cf --workspace=docs
 
+      - name: Create .env for Wrangler
+        run: |
+          echo "NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}" >> apps/docs/.env
+          echo "NEXT_PUBLIC_GTM_ID=${{ secrets.NEXT_PUBLIC_GTM_ID }}" >> apps/docs/.env
+          echo "NEXT_PUBLIC_MEILISEARCH_HOST=${{ secrets.NEXT_PUBLIC_MEILISEARCH_HOST }}" >> apps/docs/.env
+          echo "NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY=${{ secrets.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY }}" >> apps/docs/.env
+
       # Production deploy (push to main)
       - name: Deploy to Cloudflare Workers (Production)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -55,11 +62,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: "apps/docs"
           command: deploy
-          secrets: |
-            NEXT_PUBLIC_SITE_URL
-            NEXT_PUBLIC_GTM_ID
-            NEXT_PUBLIC_MEILISEARCH_HOST
-            NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY
 
       # Preview deploy (PR to main)
       - name: Upload Preview Version
@@ -71,11 +73,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: "apps/docs"
           command: versions upload
-          secrets: |
-            NEXT_PUBLIC_SITE_URL
-            NEXT_PUBLIC_GTM_ID
-            NEXT_PUBLIC_MEILISEARCH_HOST
-            NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY
 
       # Comment on PR with preview URL
       - name: Comment Preview URL on PR

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,11 @@
 name: Deploy Docs to Cloudflare Workers
 
+env:
+  NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+  NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
+  NEXT_PUBLIC_MEILISEARCH_HOST: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_HOST }}
+  NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY }}
+
 on:
   push:
     branches:
@@ -39,11 +45,6 @@ jobs:
 
       - name: Build docs
         run: npm run build:cf --workspace=docs
-        env:
-          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
-          NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
-          NEXT_PUBLIC_MEILISEARCH_HOST: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_HOST }}
-          NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY: ${{ secrets.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY }}
 
       # Production deploy (push to main)
       - name: Deploy to Cloudflare Workers (Production)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm install --frozen-lockfile
 
       - name: Build docs (with dependencies)
-        run: npx turbo build --filter=docs
+        run: npx turbo build --filter=docs --ui=stream
 
       # Production deploy (push to main)
       - name: Deploy to Cloudflare Workers (Production)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "opennextjs-cloudflare build",
+    "build": "next build",
+    "build:cf": "opennextjs-cloudflare build",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",

--- a/apps/docs/wrangler.jsonc
+++ b/apps/docs/wrangler.jsonc
@@ -35,9 +35,18 @@
     "binding": "IMAGES"
   },
   "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
     "logs": {
       "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
       "invocation_logs": false
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1
     }
   }
 }


### PR DESCRIPTION
Adds a GitHub Actions workflow to deploy the docs app to Cloudflare Workers, replacing the CF dashboard git integration.

## What it does

- **Production** (`push` to `main`): Builds via turbo and deploys with `wrangler deploy`
- **Preview** (`PR` to `main`): Builds via turbo, uploads a preview version with `wrangler versions upload`, and posts a comment on the PR with the preview URL

## How it works

The workflow builds from the monorepo root using `turbo build --filter=docs`, which automatically builds `@tailgrids/icons` first (via turbo's `^build` dependency). Then runs wrangler from `apps/docs/` where it finds `wrangler.jsonc` and the `.open-next/` build output.

Preview comments are idempotent — subsequent pushes update the same comment instead of creating duplicates.

## Secrets required

Already configured:
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`
