### PR TITLE
docs(mcp): fix incorrect package name in manual install snippets

### DIFF
--- a/apps/docs/content/mcp.mdx
+++ b/apps/docs/content/mcp.mdx
@@ -28,7 +28,7 @@ For VS Code or other similar MCP agents, add the following to your MCP settings:
   "mcpServers": {
     "tailgrids": {
       "command": "npx",
-      "args": ["-y", "@tailgrids/mcp-server@latest"]
+      "args": ["-y", "@tailgrids/mcp@latest"]
     }
   }
 }
@@ -45,7 +45,7 @@ For VS Code or other similar MCP agents, add the following to your MCP settings:
   "mcpServers": {
     "tailgrids": {
       "command": "npx",
-      "args": ["-y", "@tailgrids/mcp-server@latest"]
+      "args": ["-y", "@tailgrids/mcp@latest"]
     }
   }
 }
@@ -60,7 +60,7 @@ Add the following to your `~/.codeium/windsurf/mcp_config.json`:
   "mcpServers": {
     "tailgrids": {
       "command": "npx",
-      "args": ["-y", "@tailgrids/mcp-server@latest"]
+      "args": ["-y", "@tailgrids/mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
### Summary                                                
- Fixes incorrect npm package name in MCP manual install snippets (`@tailgrids/mcp-server` → `@tailgrids/mcp`)     
           
Reported via Discord.                                     
                                                          
### Changes
- Updated three instances in `apps/docs/content/mcp.mdx` (VS Code, Cursor, Windsurf sections)

### Test plan
- [x] Verify `npm view @tailgrids/mcp` resolves (published as 1.0.1)
- [x] Verify `npm view @tailgrids/mcp-server` returns 404