### PR TITLE
Fix import paths in documentation anatomy and usage section

### DIFF
--- a/apps/docs/content/components/alert.mdx
+++ b/apps/docs/content/components/alert.mdx
@@ -58,7 +58,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import Alert from "@/components/tailgrids/alert";
+import Alert from "@/components/tailgrids/core/alert";
 import { CheckCircle1 } from "@tailgrids/icons";
 
 export default () => (

--- a/apps/docs/content/components/alert.mdx
+++ b/apps/docs/content/components/alert.mdx
@@ -58,7 +58,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import Alert from "@/registry/core/alert";
+import Alert from "@/components/tailgrids/alert";
 import { CheckCircle1 } from "@tailgrids/icons";
 
 export default () => (

--- a/apps/docs/content/components/aspect-ratio.mdx
+++ b/apps/docs/content/components/aspect-ratio.mdx
@@ -60,7 +60,7 @@ lang="tsx"
 Import the component and pass the desired aspect ratio variant or custom ratio.
 
 ```tsx
-import { AspectRatio } from "@/registry/core/aspect-ratio";
+import { AspectRatio } from "@/components/tailgrids/aspect-ratio";
 
 export const AspectRatioExample = () => (
   <AspectRatio ratio="video" className="rounded-lg overflow-hidden">

--- a/apps/docs/content/components/aspect-ratio.mdx
+++ b/apps/docs/content/components/aspect-ratio.mdx
@@ -60,7 +60,7 @@ lang="tsx"
 Import the component and pass the desired aspect ratio variant or custom ratio.
 
 ```tsx
-import { AspectRatio } from "@/components/tailgrids/aspect-ratio";
+import { AspectRatio } from "@/components/tailgrids/core/aspect-ratio";
 
 export const AspectRatioExample = () => (
   <AspectRatio ratio="video" className="rounded-lg overflow-hidden">

--- a/apps/docs/content/components/avatar.mdx
+++ b/apps/docs/content/components/avatar.mdx
@@ -59,7 +59,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Avatar } from "@/components/tailgrids/avatar";
+import { Avatar } from "@/components/tailgrids/core/avatar";
 
 export const AvatarExample = () => (
   <Avatar

--- a/apps/docs/content/components/avatar.mdx
+++ b/apps/docs/content/components/avatar.mdx
@@ -59,7 +59,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Avatar } from "@/registry/core/avatar";
+import { Avatar } from "@/components/tailgrids/avatar";
 
 export const AvatarExample = () => (
   <Avatar

--- a/apps/docs/content/components/breadcrumbs.mdx
+++ b/apps/docs/content/components/breadcrumbs.mdx
@@ -58,7 +58,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { Breadcrumbs } from "@/registry/core/breadcrumbs";
+import { Breadcrumbs } from "@/components/tailgrids/breadcrumbs";
 
 export const BreadcrumbsExample = () => (
   <Breadcrumbs

--- a/apps/docs/content/components/breadcrumbs.mdx
+++ b/apps/docs/content/components/breadcrumbs.mdx
@@ -58,7 +58,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { Breadcrumbs } from "@/components/tailgrids/breadcrumbs";
+import { Breadcrumbs } from "@/components/tailgrids/core/breadcrumbs";
 
 export const BreadcrumbsExample = () => (
   <Breadcrumbs

--- a/apps/docs/content/components/button-group.mdx
+++ b/apps/docs/content/components/button-group.mdx
@@ -59,7 +59,7 @@ Copy and paste the following component code into your project.
 Import the component and wrap related buttons inside it.
 
 ```tsx
-import { ButtonGroup } from "@/components/tailgrids/button-group";
+import { ButtonGroup } from "@/components/tailgrids/core/button-group";
 
 export const ButtonGroupExample = () => (
   <ButtonGroup>

--- a/apps/docs/content/components/button-group.mdx
+++ b/apps/docs/content/components/button-group.mdx
@@ -59,7 +59,7 @@ Copy and paste the following component code into your project.
 Import the component and wrap related buttons inside it.
 
 ```tsx
-import { ButtonGroup } from "@/registry/core/button-group";
+import { ButtonGroup } from "@/components/tailgrids/button-group";
 
 export const ButtonGroupExample = () => (
   <ButtonGroup>

--- a/apps/docs/content/components/button.mdx
+++ b/apps/docs/content/components/button.mdx
@@ -62,7 +62,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { Button } from "@/components/tailgrids/button";
+import { Button } from "@/components/tailgrids/core/button";
 
 export const ButtonExample = () => <Button variant="primary">Click me</Button>;
 ```

--- a/apps/docs/content/components/button.mdx
+++ b/apps/docs/content/components/button.mdx
@@ -62,7 +62,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { Button } from "@/registry/core/button";
+import { Button } from "@/components/tailgrids/button";
 
 export const ButtonExample = () => <Button variant="primary">Click me</Button>;
 ```

--- a/apps/docs/content/components/card.mdx
+++ b/apps/docs/content/components/card.mdx
@@ -71,7 +71,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle
-} from "@/components/tailgrids/card";
+} from "@/components/tailgrids/core/card";
 
 export function CardDemo() {
   return (

--- a/apps/docs/content/components/card.mdx
+++ b/apps/docs/content/components/card.mdx
@@ -71,7 +71,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle
-} from "@/registry/core/card";
+} from "@/components/tailgrids/card";
 
 export function CardDemo() {
   return (

--- a/apps/docs/content/components/chart.mdx
+++ b/apps/docs/content/components/chart.mdx
@@ -68,7 +68,7 @@ import {
   ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent
-} from "@/components/tailgrids/chart";
+} from "@/components/tailgrids/core/chart";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 export const ChartExample = () => {

--- a/apps/docs/content/components/chart.mdx
+++ b/apps/docs/content/components/chart.mdx
@@ -68,7 +68,7 @@ import {
   ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent
-} from "@/registry/core/chart";
+} from "@/components/tailgrids/chart";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 export const ChartExample = () => {

--- a/apps/docs/content/components/checkbox.mdx
+++ b/apps/docs/content/components/checkbox.mdx
@@ -8,7 +8,7 @@ import CheckboxControlledPreview from "@/components/preview/checkbox/checkbox-co
 import CheckboxPreview from "@/components/preview/checkbox/checkbox-preview";
 import CheckboxSizesPreview from "@/components/preview/checkbox/checkbox-sizes-preview";
 import CheckboxWithLabelPreview from "@/components/preview/checkbox/checkbox-with-label-preview";
-import { Checkbox } from "@/components/tailgrids/checkbox";
+import { Checkbox } from "@/registry/core/checkbox";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -62,8 +62,8 @@ You'll also need the check icon SVG referenced in the component.
 Import the component and either provide an accessible name directly or pair it with the standalone `Label` component.
 
 ```tsx
-import { Checkbox } from "@/components/tailgrids/checkbox";
-import { Label } from "@/components/tailgrids/label";
+import { Checkbox } from "@/components/tailgrids/core/checkbox";
+import { Label } from "@/components/tailgrids/core/label";
 import { useId } from "react";
 
 export default function CheckboxExample() {

--- a/apps/docs/content/components/checkbox.mdx
+++ b/apps/docs/content/components/checkbox.mdx
@@ -8,7 +8,7 @@ import CheckboxControlledPreview from "@/components/preview/checkbox/checkbox-co
 import CheckboxPreview from "@/components/preview/checkbox/checkbox-preview";
 import CheckboxSizesPreview from "@/components/preview/checkbox/checkbox-sizes-preview";
 import CheckboxWithLabelPreview from "@/components/preview/checkbox/checkbox-with-label-preview";
-import { Checkbox } from "@/registry/core/checkbox";
+import { Checkbox } from "@/components/tailgrids/checkbox";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -62,8 +62,8 @@ You'll also need the check icon SVG referenced in the component.
 Import the component and either provide an accessible name directly or pair it with the standalone `Label` component.
 
 ```tsx
-import { Checkbox } from "@/registry/core/checkbox";
-import { Label } from "@/registry/core/label";
+import { Checkbox } from "@/components/tailgrids/checkbox";
+import { Label } from "@/components/tailgrids/label";
 import { useId } from "react";
 
 export default function CheckboxExample() {
@@ -122,17 +122,17 @@ Control the checked state using React state.
 
 Extends `input` element props.
 
-| Prop             | Type                       | Default | Description                                              |
-| ---------------- | -------------------------- | ------- | -------------------------------------------------------- |
-| `id`             | `string`                   | -       | Input ID used with the standalone `Label` component      |
-| `className`      | `string`                   | -       | Additional wrapper classes                               |
-| `size`           | `'sm' \| 'md'`             | `'sm'`  | Checkbox size                                            |
-| `disabled`       | `boolean`                  | `false` | Disable checkbox interaction                             |
-| `checked`        | `boolean`                  | -       | Controlled checked state                                 |
-| `defaultChecked` | `boolean`                  | -       | Uncontrolled default checked state                       |
-| `aria-label`     | `string`                   | -       | Accessible name when no visible label is used           |
-| `aria-labelledby` | `string`                  | -       | Accessible name via an external label element           |
-| `onChange`       | `(e: ChangeEvent) => void` | -       | Change event handler                                     |
+| Prop              | Type                       | Default | Description                                         |
+| ----------------- | -------------------------- | ------- | --------------------------------------------------- |
+| `id`              | `string`                   | -       | Input ID used with the standalone `Label` component |
+| `className`       | `string`                   | -       | Additional wrapper classes                          |
+| `size`            | `'sm' \| 'md'`             | `'sm'`  | Checkbox size                                       |
+| `disabled`        | `boolean`                  | `false` | Disable checkbox interaction                        |
+| `checked`         | `boolean`                  | -       | Controlled checked state                            |
+| `defaultChecked`  | `boolean`                  | -       | Uncontrolled default checked state                  |
+| `aria-label`      | `string`                   | -       | Accessible name when no visible label is used       |
+| `aria-labelledby` | `string`                   | -       | Accessible name via an external label element       |
+| `onChange`        | `(e: ChangeEvent) => void` | -       | Change event handler                                |
 
 ## Accessibility
 

--- a/apps/docs/content/components/collapsible.mdx
+++ b/apps/docs/content/components/collapsible.mdx
@@ -89,7 +89,7 @@ import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent
-} from "@/components/tailgrids/collapsible";
+} from "@/components/tailgrids/core/collapsible";
 
 export default function Example() {
   return (

--- a/apps/docs/content/components/collapsible.mdx
+++ b/apps/docs/content/components/collapsible.mdx
@@ -89,7 +89,7 @@ import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent
-} from "@/registry/core/collapsible";
+} from "@/components/tailgrids/collapsible";
 
 export default function Example() {
   return (

--- a/apps/docs/content/components/combobox.mdx
+++ b/apps/docs/content/components/combobox.mdx
@@ -87,7 +87,7 @@ import {
   ComboboxContent,
   ComboboxEmpty,
   ComboboxTrigger
-} from "@/registry/core/combobox/combobox";
+} from "@/components/tailgrids/combobox";
 
 export default function ComboboxExample() {
   return (

--- a/apps/docs/content/components/combobox.mdx
+++ b/apps/docs/content/components/combobox.mdx
@@ -87,7 +87,7 @@ import {
   ComboboxContent,
   ComboboxEmpty,
   ComboboxTrigger
-} from "@/components/tailgrids/combobox";
+} from "@/components/tailgrids/core/combobox";
 
 export default function ComboboxExample() {
   return (

--- a/apps/docs/content/components/command.mdx
+++ b/apps/docs/content/components/command.mdx
@@ -68,7 +68,7 @@ import {
   CommandList,
   CommandSeparator,
   CommandShortcut
-} from "@/registry/core/command";
+} from "@/components/tailgrids/command";
 
 export function CommandDemo() {
   return (

--- a/apps/docs/content/components/command.mdx
+++ b/apps/docs/content/components/command.mdx
@@ -68,7 +68,7 @@ import {
   CommandList,
   CommandSeparator,
   CommandShortcut
-} from "@/components/tailgrids/command";
+} from "@/components/tailgrids/core/command";
 
 export function CommandDemo() {
   return (

--- a/apps/docs/content/components/date-picker.mdx
+++ b/apps/docs/content/components/date-picker.mdx
@@ -66,7 +66,7 @@ Copy and paste the code into `single-date.tsx` (for `DatePicker`) and `range-dat
 The following example demonstrates how to use the single DatePicker component.
 
 ```tsx
-import { DatePicker } from "@/registry/core/date-picker/single-date";
+import { DatePicker } from "@/components/tailgrids/date-picker/single-date";
 import * as React from "react";
 
 export default function DatePickerUsage() {

--- a/apps/docs/content/components/date-picker.mdx
+++ b/apps/docs/content/components/date-picker.mdx
@@ -66,7 +66,7 @@ Copy and paste the code into `single-date.tsx` (for `DatePicker`) and `range-dat
 The following example demonstrates how to use the single DatePicker component.
 
 ```tsx
-import { DatePicker } from "@/components/tailgrids/date-picker/single-date";
+import { DatePicker } from "@/components/tailgrids/core/date-picker/single-date";
 import * as React from "react";
 
 export default function DatePickerUsage() {

--- a/apps/docs/content/components/dialog.mdx
+++ b/apps/docs/content/components/dialog.mdx
@@ -77,7 +77,7 @@ import {
   DialogBody,
   DialogFooter,
   DialogClose
-} from "@/registry/core/dialog";
+} from "@/components/tailgrids/dialog";
 
 export default function DialogAnatomy() {
   return (
@@ -115,7 +115,7 @@ import {
   DialogDescription,
   DialogFooter,
   DialogClose
-} from "@/registry/core/dialog";
+} from "@/components/tailgrids/dialog";
 
 export default function DialogExample() {
   return (

--- a/apps/docs/content/components/dialog.mdx
+++ b/apps/docs/content/components/dialog.mdx
@@ -77,7 +77,7 @@ import {
   DialogBody,
   DialogFooter,
   DialogClose
-} from "@/components/tailgrids/dialog";
+} from "@/components/tailgrids/core/dialog";
 
 export default function DialogAnatomy() {
   return (
@@ -115,7 +115,7 @@ import {
   DialogDescription,
   DialogFooter,
   DialogClose
-} from "@/components/tailgrids/dialog";
+} from "@/components/tailgrids/core/dialog";
 
 export default function DialogExample() {
   return (

--- a/apps/docs/content/components/drawer.mdx
+++ b/apps/docs/content/components/drawer.mdx
@@ -72,7 +72,7 @@ import {
   DrawerBody,
   DrawerFooter,
   DrawerClose
-} from "@/registry/core/drawer";
+} from "@/components/tailgrids/drawer";
 
 export default function DrawerAnatomy() {
   return (
@@ -105,7 +105,7 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerDescription
-} from "@/registry/core/drawer";
+} from "@/components/tailgrids/drawer";
 
 export default function DrawerExample() {
   return (

--- a/apps/docs/content/components/drawer.mdx
+++ b/apps/docs/content/components/drawer.mdx
@@ -72,7 +72,7 @@ import {
   DrawerBody,
   DrawerFooter,
   DrawerClose
-} from "@/components/tailgrids/drawer";
+} from "@/components/tailgrids/core/drawer";
 
 export default function DrawerAnatomy() {
   return (
@@ -105,7 +105,7 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerDescription
-} from "@/components/tailgrids/drawer";
+} from "@/components/tailgrids/core/drawer";
 
 export default function DrawerExample() {
   return (

--- a/apps/docs/content/components/dropdown.mdx
+++ b/apps/docs/content/components/dropdown.mdx
@@ -66,7 +66,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator
-} from "@/registry/core/dropdown";
+} from "@/components/tailgrids/dropdown";
 
 export const DropdownExample = () => (
   <DropdownMenu>
@@ -97,8 +97,8 @@ import {
   DropdownMenuSection,
   DropdownMenuHeader,
   DropdownMenuSeparator
-} from "@/registry/core/dropdown";
-import { Button } from "@/registry/core/button";
+} from "@/components/tailgrids/dropdown";
+import { Button } from "@/components/tailgrids/button";
 
 export const DropdownUsageExample = () => (
   <DropdownMenu>

--- a/apps/docs/content/components/dropdown.mdx
+++ b/apps/docs/content/components/dropdown.mdx
@@ -66,7 +66,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator
-} from "@/components/tailgrids/dropdown";
+} from "@/components/tailgrids/core/dropdown";
 
 export const DropdownExample = () => (
   <DropdownMenu>
@@ -97,8 +97,8 @@ import {
   DropdownMenuSection,
   DropdownMenuHeader,
   DropdownMenuSeparator
-} from "@/components/tailgrids/dropdown";
-import { Button } from "@/components/tailgrids/button";
+} from "@/components/tailgrids/core/dropdown";
+import { Button } from "@/components/tailgrids/core/button";
 
 export const DropdownUsageExample = () => (
   <DropdownMenu>

--- a/apps/docs/content/components/field.mdx
+++ b/apps/docs/content/components/field.mdx
@@ -74,7 +74,7 @@ import {
   FieldError,
   FieldSeparator,
   ComposedField
-} from "@/components/tailgrids/core/Field";
+} from "@/components/tailgrids/core/field";
 
 export const FieldAnatomy = () => (
   <FieldSet>

--- a/apps/docs/content/components/field.mdx
+++ b/apps/docs/content/components/field.mdx
@@ -74,7 +74,7 @@ import {
   FieldError,
   FieldSeparator,
   ComposedField
-} from "@/components/tailgrids/Field";
+} from "@/components/tailgrids/core/Field";
 
 export const FieldAnatomy = () => (
   <FieldSet>

--- a/apps/docs/content/components/field.mdx
+++ b/apps/docs/content/components/field.mdx
@@ -74,7 +74,7 @@ import {
   FieldError,
   FieldSeparator,
   ComposedField
-} from "@/registry/core/Field";
+} from "@/components/tailgrids/Field";
 
 export const FieldAnatomy = () => (
   <FieldSet>

--- a/apps/docs/content/components/hover-card.mdx
+++ b/apps/docs/content/components/hover-card.mdx
@@ -65,7 +65,7 @@ import {
   HoverCard,
   HoverCardTrigger,
   HoverCardContent
-} from "@/registry/core/hover-card";
+} from "@/components/tailgrids/hover-card";
 
 export const HoverCardAnatomy = () => (
   <HoverCard>

--- a/apps/docs/content/components/hover-card.mdx
+++ b/apps/docs/content/components/hover-card.mdx
@@ -65,7 +65,7 @@ import {
   HoverCard,
   HoverCardTrigger,
   HoverCardContent
-} from "@/components/tailgrids/hover-card";
+} from "@/components/tailgrids/core/hover-card";
 
 export const HoverCardAnatomy = () => (
   <HoverCard>

--- a/apps/docs/content/components/input-group.mdx
+++ b/apps/docs/content/components/input-group.mdx
@@ -67,7 +67,7 @@ import {
   InputGroupInput,
   InputGroupButton,
   InputGroupTextarea
-} from "@/components/tailgrids/input-group";
+} from "@/components/tailgrids/core/input-group";
 import { Search1 } from "@tailgrids/icons";
 
 export const InputGroupExample = () => (

--- a/apps/docs/content/components/input-group.mdx
+++ b/apps/docs/content/components/input-group.mdx
@@ -67,7 +67,7 @@ import {
   InputGroupInput,
   InputGroupButton,
   InputGroupTextarea
-} from "@/registry/core/input-group";
+} from "@/components/tailgrids/input-group";
 import { Search1 } from "@tailgrids/icons";
 
 export const InputGroupExample = () => (

--- a/apps/docs/content/components/input.mdx
+++ b/apps/docs/content/components/input.mdx
@@ -9,7 +9,7 @@ import InputPreview from "@/components/preview/input/input-preview";
 import InputStatesPreview from "@/components/preview/input/input-states-preview";
 import InputWithHintPreview from "@/components/preview/input/input-with-hint-preview";
 import InputWithLabelPreview from "@/components/preview/input/input-with-label-preview";
-import { Input } from "@/components/tailgrids/input";
+import { Input } from "@/registry/core/input";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -63,8 +63,8 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props. Use the `Label` component to provide a label for the input.
 
 ```tsx
-import { Input } from "@/components/tailgrids/input";
-import { Label } from "@/components/tailgrids/label";
+import { Input } from "@/components/tailgrids/core/input";
+import { Label } from "@/components/tailgrids/core/label";
 import { useId } from "react";
 
 export default function InputPreview() {

--- a/apps/docs/content/components/input.mdx
+++ b/apps/docs/content/components/input.mdx
@@ -9,7 +9,7 @@ import InputPreview from "@/components/preview/input/input-preview";
 import InputStatesPreview from "@/components/preview/input/input-states-preview";
 import InputWithHintPreview from "@/components/preview/input/input-with-hint-preview";
 import InputWithLabelPreview from "@/components/preview/input/input-with-label-preview";
-import { Input } from "@/registry/core/input";
+import { Input } from "@/components/tailgrids/input";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -63,8 +63,8 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props. Use the `Label` component to provide a label for the input.
 
 ```tsx
-import { Input } from "@/registry/core/input";
-import { Label } from "@/registry/core/label";
+import { Input } from "@/components/tailgrids/input";
+import { Label } from "@/components/tailgrids/label";
 import { useId } from "react";
 
 export default function InputPreview() {

--- a/apps/docs/content/components/label.mdx
+++ b/apps/docs/content/components/label.mdx
@@ -59,7 +59,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Label } from "@/registry/core/label";
+import { Label } from "@/components/tailgrids/label";
 
 export const LabelExample = () => <Label htmlFor="input-id">Label Text</Label>;
 ```

--- a/apps/docs/content/components/label.mdx
+++ b/apps/docs/content/components/label.mdx
@@ -59,7 +59,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Label } from "@/components/tailgrids/label";
+import { Label } from "@/components/tailgrids/core/label";
 
 export const LabelExample = () => <Label htmlFor="input-id">Label Text</Label>;
 ```

--- a/apps/docs/content/components/link.mdx
+++ b/apps/docs/content/components/link.mdx
@@ -58,7 +58,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { Link } from "@/registry/core/link";
+import { Link } from "@/components/tailgrids/link";
 
 export default function Example() {
   return <Link href="/about">Learn more</Link>;

--- a/apps/docs/content/components/link.mdx
+++ b/apps/docs/content/components/link.mdx
@@ -58,7 +58,7 @@ Copy and paste the following component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { Link } from "@/components/tailgrids/link";
+import { Link } from "@/components/tailgrids/core/link";
 
 export default function Example() {
   return <Link href="/about">Learn more</Link>;

--- a/apps/docs/content/components/list.mdx
+++ b/apps/docs/content/components/list.mdx
@@ -64,7 +64,7 @@ Copy and paste the following component code into your project.
 Import the component and render list items as children.
 
 ```tsx
-import { List } from "@/components/tailgrids/list";
+import { List } from "@/components/tailgrids/core/list";
 
 export default function Example() {
   return (

--- a/apps/docs/content/components/list.mdx
+++ b/apps/docs/content/components/list.mdx
@@ -64,7 +64,7 @@ Copy and paste the following component code into your project.
 Import the component and render list items as children.
 
 ```tsx
-import { List } from "@/registry/core/list";
+import { List } from "@/components/tailgrids/list";
 
 export default function Example() {
   return (

--- a/apps/docs/content/components/native-select.mdx
+++ b/apps/docs/content/components/native-select.mdx
@@ -1,7 +1,6 @@
 ---
 title: Native Select Components
 description: A Native select component built with React and Tailwind CSS. Create dropdown menus using the browser’s select input with mobile-friendly behavior and built-in accessibility.
-
 ---
 
 import NativeSelectDisabledPreview from "@/components/preview/native-select/native-select-disabled-preview";
@@ -65,7 +64,7 @@ Import the component and pass the required props.
 import {
   NativeSelect,
   NativeSelectOption
-} from "@/registry/core/native-select";
+} from "@/components/tailgrids/native-select";
 
 export const NativeSelectExample = () => (
   <NativeSelect>
@@ -147,7 +146,6 @@ Use `NativeSelectOptGroup` to group related options together.
 | Prop        | Type     | Default | Description            |
 | :---------- | :------- | :------ | :--------------------- |
 | `className` | `string` | -       | Additional CSS classes |
-
 
 ## Accessibility
 

--- a/apps/docs/content/components/native-select.mdx
+++ b/apps/docs/content/components/native-select.mdx
@@ -64,7 +64,7 @@ Import the component and pass the required props.
 import {
   NativeSelect,
   NativeSelectOption
-} from "@/components/tailgrids/native-select";
+} from "@/components/tailgrids/core/native-select";
 
 export const NativeSelectExample = () => (
   <NativeSelect>

--- a/apps/docs/content/components/navigation-menu.mdx
+++ b/apps/docs/content/components/navigation-menu.mdx
@@ -67,7 +67,7 @@ import {
   NavigationMenuTrigger,
   NavigationMenuIndicator,
   NavigationMenuPositioner
-} from "@/registry/core/navigation-menu";
+} from "@/components/tailgrids/navigation-menu";
 
 export const NavigationMenuExample = () => (
   <NavigationMenu>
@@ -101,7 +101,7 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger,
   NavigationMenuPositioner
-} from "@/registry/core/navigation-menu";
+} from "@/components/tailgrids/navigation-menu";
 
 export default function NavigationMenuExample() {
   return (

--- a/apps/docs/content/components/navigation-menu.mdx
+++ b/apps/docs/content/components/navigation-menu.mdx
@@ -67,7 +67,7 @@ import {
   NavigationMenuTrigger,
   NavigationMenuIndicator,
   NavigationMenuPositioner
-} from "@/components/tailgrids/navigation-menu";
+} from "@/components/tailgrids/core/navigation-menu";
 
 export const NavigationMenuExample = () => (
   <NavigationMenu>
@@ -101,7 +101,7 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger,
   NavigationMenuPositioner
-} from "@/components/tailgrids/navigation-menu";
+} from "@/components/tailgrids/core/navigation-menu";
 
 export default function NavigationMenuExample() {
   return (

--- a/apps/docs/content/components/otp-input.mdx
+++ b/apps/docs/content/components/otp-input.mdx
@@ -63,7 +63,7 @@ lang="tsx"
 Import the component and control the OTP value using state.
 
 ```tsx
-import { OtpInput } from "@/registry/core/otp-input";
+import { OtpInput } from "@/components/tailgrids/otp-input";
 
 export default OtpInputPreview = () => {
   const [value, setValue] = useState("");

--- a/apps/docs/content/components/otp-input.mdx
+++ b/apps/docs/content/components/otp-input.mdx
@@ -63,7 +63,7 @@ lang="tsx"
 Import the component and control the OTP value using state.
 
 ```tsx
-import { OtpInput } from "@/components/tailgrids/otp-input";
+import { OtpInput } from "@/components/tailgrids/core/otp-input";
 
 export default OtpInputPreview = () => {
   const [value, setValue] = useState("");

--- a/apps/docs/content/components/pagination.mdx
+++ b/apps/docs/content/components/pagination.mdx
@@ -62,7 +62,7 @@ Copy and paste the following component code into your project.
 Import the component and control the active page using state.
 
 ```tsx
-import { Pagination } from "@/components/tailgrids/pagination";
+import { Pagination } from "@/components/tailgrids/core/pagination";
 
 export default PaginationExample = () => (
   <Pagination

--- a/apps/docs/content/components/pagination.mdx
+++ b/apps/docs/content/components/pagination.mdx
@@ -62,7 +62,7 @@ Copy and paste the following component code into your project.
 Import the component and control the active page using state.
 
 ```tsx
-import { Pagination } from "@/registry/core/pagination";
+import { Pagination } from "@/components/tailgrids/pagination";
 
 export default PaginationExample = () => (
   <Pagination

--- a/apps/docs/content/components/pagination.mdx
+++ b/apps/docs/content/components/pagination.mdx
@@ -64,13 +64,15 @@ Import the component and control the active page using state.
 ```tsx
 import { Pagination } from "@/components/tailgrids/core/pagination";
 
-export default PaginationExample = () => (
+const PaginationExample = () => (
   <Pagination
     currentPage={2}
     totalPages={10}
     onPageChange={p => console.log(p)}
   />
 );
+
+export default PaginationExample;
 ```
 
 ## Examples

--- a/apps/docs/content/components/popover.mdx
+++ b/apps/docs/content/components/popover.mdx
@@ -72,7 +72,7 @@ import {
   PopoverHeading,
   PopoverDescription,
   PopoverClose
-} from "@/components/tailgrids/popover";
+} from "@/components/tailgrids/core/popover";
 
 export default function PopoverAnatomy() {
   return (
@@ -100,7 +100,7 @@ import {
   PopoverHeading,
   PopoverDescription,
   PopoverClose
-} from "@/components/tailgrids/popover";
+} from "@/components/tailgrids/core/popover";
 
 export default function PopoverExample() {
   return (

--- a/apps/docs/content/components/popover.mdx
+++ b/apps/docs/content/components/popover.mdx
@@ -72,7 +72,7 @@ import {
   PopoverHeading,
   PopoverDescription,
   PopoverClose
-} from "@/registry/core/popover";
+} from "@/components/tailgrids/popover";
 
 export default function PopoverAnatomy() {
   return (
@@ -100,7 +100,7 @@ import {
   PopoverHeading,
   PopoverDescription,
   PopoverClose
-} from "@/registry/core/popover";
+} from "@/components/tailgrids/popover";
 
 export default function PopoverExample() {
   return (

--- a/apps/docs/content/components/progress.mdx
+++ b/apps/docs/content/components/progress.mdx
@@ -53,7 +53,7 @@ Copy the `Progress` component code into your project. No additional dependencies
 Import the component and pass the progress value.
 
 ```tsx
-import { Progress } from "@/registry/core/progress";
+import { Progress } from "@/components/tailgrids/progress";
 
 export default function ProgressBasic() {
   return <Progress progress={50} withLabel />;

--- a/apps/docs/content/components/progress.mdx
+++ b/apps/docs/content/components/progress.mdx
@@ -53,7 +53,7 @@ Copy the `Progress` component code into your project. No additional dependencies
 Import the component and pass the progress value.
 
 ```tsx
-import { Progress } from "@/components/tailgrids/progress";
+import { Progress } from "@/components/tailgrids/core/progress";
 
 export default function ProgressBasic() {
   return <Progress progress={50} withLabel />;

--- a/apps/docs/content/components/radio-input.mdx
+++ b/apps/docs/content/components/radio-input.mdx
@@ -63,8 +63,8 @@ Copy and paste the following component code into your project.
 Import the component and the `Label` component, then wrap the `RadioInput` within the `Label` for proper association.
 
 ```tsx
-import { Label } from "@/components/tailgrids/label";
-import { RadioInput } from "@/components/tailgrids/radio-input";
+import { Label } from "@/components/tailgrids/core/label";
+import { RadioInput } from "@/components/tailgrids/core/radio-input";
 
 export default function RadioWithLabelPreview() {
   return (

--- a/apps/docs/content/components/radio-input.mdx
+++ b/apps/docs/content/components/radio-input.mdx
@@ -63,8 +63,8 @@ Copy and paste the following component code into your project.
 Import the component and the `Label` component, then wrap the `RadioInput` within the `Label` for proper association.
 
 ```tsx
-import { Label } from "@/registry/core/label";
-import { RadioInput } from "@/registry/core/radio-input";
+import { Label } from "@/components/tailgrids/label";
+import { RadioInput } from "@/components/tailgrids/radio-input";
 
 export default function RadioWithLabelPreview() {
   return (

--- a/apps/docs/content/components/select.mdx
+++ b/apps/docs/content/components/select.mdx
@@ -69,7 +69,7 @@ import {
   SelectIndicator,
   SelectItem,
   SelectTrigger
-} from "@/registry/core/select";
+} from "@/components/tailgrids/select";
 
 export default function SelectExample() {
   return (

--- a/apps/docs/content/components/select.mdx
+++ b/apps/docs/content/components/select.mdx
@@ -69,7 +69,7 @@ import {
   SelectIndicator,
   SelectItem,
   SelectTrigger
-} from "@/components/tailgrids/select";
+} from "@/components/tailgrids/core/select";
 
 export default function SelectExample() {
   return (

--- a/apps/docs/content/components/separator.mdx
+++ b/apps/docs/content/components/separator.mdx
@@ -58,7 +58,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Separator } from "@/components/tailgrids/separator";
+import { Separator } from "@/components/tailgrids/core/separator";
 
 export const SeparatorExample = () => <Separator />;
 ```

--- a/apps/docs/content/components/separator.mdx
+++ b/apps/docs/content/components/separator.mdx
@@ -58,7 +58,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Separator } from "@/registry/core/separator";
+import { Separator } from "@/components/tailgrids/separator";
 
 export const SeparatorExample = () => <Separator />;
 ```

--- a/apps/docs/content/components/sheet.mdx
+++ b/apps/docs/content/components/sheet.mdx
@@ -73,7 +73,7 @@ import {
   SheetBody,
   SheetFooter,
   SheetClose
-} from "@/registry/core/sheet";
+} from "@/components/tailgrids/sheet";
 
 export default function SheetAnatomy() {
   return (
@@ -109,7 +109,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetDescription
-} from "@/registry/core/sheet";
+} from "@/components/tailgrids/sheet";
 
 export default function SheetExample() {
   return (

--- a/apps/docs/content/components/sheet.mdx
+++ b/apps/docs/content/components/sheet.mdx
@@ -73,7 +73,7 @@ import {
   SheetBody,
   SheetFooter,
   SheetClose
-} from "@/components/tailgrids/sheet";
+} from "@/components/tailgrids/core/sheet";
 
 export default function SheetAnatomy() {
   return (
@@ -109,7 +109,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetDescription
-} from "@/components/tailgrids/sheet";
+} from "@/components/tailgrids/core/sheet";
 
 export default function SheetExample() {
   return (

--- a/apps/docs/content/components/sidebar.mdx
+++ b/apps/docs/content/components/sidebar.mdx
@@ -64,7 +64,10 @@ The Sidebar is composed of several complementary primitives allowing you to buil
 A typical application layout places a `SidebarProvider` wrapping your entire application shell. Inside it goes your `Sidebar` (which behaves like navigation off-canvas) alongside your `<main>` content container.
 
 ```tsx
-import { SidebarProvider, SidebarTrigger } from "@/registry/core/sidebar";
+import {
+  SidebarProvider,
+  SidebarTrigger
+} from "@/components/tailgrids/sidebar";
 import { AppSidebar } from "./app-sidebar";
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/docs/content/components/sidebar.mdx
+++ b/apps/docs/content/components/sidebar.mdx
@@ -67,7 +67,7 @@ A typical application layout places a `SidebarProvider` wrapping your entire app
 import {
   SidebarProvider,
   SidebarTrigger
-} from "@/components/tailgrids/sidebar";
+} from "@/components/tailgrids/core/sidebar";
 import { AppSidebar } from "./app-sidebar";
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/docs/content/components/skeleton.mdx
+++ b/apps/docs/content/components/skeleton.mdx
@@ -96,7 +96,7 @@ Add the custom pulse animation to your `tailwind` config:
 The Skeleton component provides a base animation. You can customize its dimensions by adjusting the height and width using `className` prop to match your layout requirements.
 
 ```tsx
-import { Skeleton } from "@/components/tailgrids/skeleton";
+import { Skeleton } from "@/components/tailgrids/core/skeleton";
 
 export default function SkeletonUsage() {
   return <Skeleton className="h-4 w-48" />;

--- a/apps/docs/content/components/skeleton.mdx
+++ b/apps/docs/content/components/skeleton.mdx
@@ -96,7 +96,7 @@ Add the custom pulse animation to your `tailwind` config:
 The Skeleton component provides a base animation. You can customize its dimensions by adjusting the height and width using `className` prop to match your layout requirements.
 
 ```tsx
-import { Skeleton } from "@/registry/core/skeleton";
+import { Skeleton } from "@/components/tailgrids/skeleton";
 
 export default function SkeletonUsage() {
   return <Skeleton className="h-4 w-48" />;

--- a/apps/docs/content/components/slider.mdx
+++ b/apps/docs/content/components/slider.mdx
@@ -61,7 +61,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Slider } from "@/components/tailgrids/slider";
+import { Slider } from "@/components/tailgrids/core/slider";
 
 export const SliderExample = () => (
   <Slider defaultValue={[50]} maxValue={100} minValue={0} />

--- a/apps/docs/content/components/slider.mdx
+++ b/apps/docs/content/components/slider.mdx
@@ -61,7 +61,7 @@ lang="tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Slider } from "@/registry/core/slider";
+import { Slider } from "@/components/tailgrids/slider";
 
 export const SliderExample = () => (
   <Slider defaultValue={[50]} maxValue={100} minValue={0} />

--- a/apps/docs/content/components/social-button.mdx
+++ b/apps/docs/content/components/social-button.mdx
@@ -65,7 +65,7 @@ Copy and paste the following component code into your project. Make sure you hav
 Import the component and provide an icon and label.
 
 ```tsx
-import { SocialButton } from "@/registry/core/social-button";
+import { SocialButton } from "@/components/tailgrids/social-button";
 
 const SocialButtonUsage = () => (
   <SocialButton>

--- a/apps/docs/content/components/social-button.mdx
+++ b/apps/docs/content/components/social-button.mdx
@@ -65,7 +65,7 @@ Copy and paste the following component code into your project. Make sure you hav
 Import the component and provide an icon and label.
 
 ```tsx
-import { SocialButton } from "@/components/tailgrids/social-button";
+import { SocialButton } from "@/components/tailgrids/core/social-button";
 
 const SocialButtonUsage = () => (
   <SocialButton>

--- a/apps/docs/content/components/spinner.mdx
+++ b/apps/docs/content/components/spinner.mdx
@@ -82,7 +82,7 @@ You'll also need the spinner components referenced in the component (`default.ts
 Import the component and render it where a loading state is needed.
 
 ```tsx
-import { Spinner } from "@/components/tailgrids/spinner";
+import { Spinner } from "@/components/tailgrids/core/spinner";
 
 export default function SpinnerExample() {
   return <Spinner />;

--- a/apps/docs/content/components/spinner.mdx
+++ b/apps/docs/content/components/spinner.mdx
@@ -82,7 +82,7 @@ You'll also need the spinner components referenced in the component (`default.ts
 Import the component and render it where a loading state is needed.
 
 ```tsx
-import { Spinner } from "@/registry/core/spinner";
+import { Spinner } from "@/components/tailgrids/spinner";
 
 export default function SpinnerExample() {
   return <Spinner />;

--- a/apps/docs/content/components/table.mdx
+++ b/apps/docs/content/components/table.mdx
@@ -66,7 +66,7 @@ import {
   TableHead,
   TableRow,
   TableCell
-} from "@/registry/core/table";
+} from "@/components/tailgrids/table";
 
 export default TablePreview = () => (
   <TableRoot>
@@ -94,7 +94,7 @@ import {
   TableHead,
   TableRow,
   TableCell
-} from "@/registry/core/table";
+} from "@/components/tailgrids/table";
 
 export default function TableExample() {
   return (

--- a/apps/docs/content/components/table.mdx
+++ b/apps/docs/content/components/table.mdx
@@ -66,7 +66,7 @@ import {
   TableHead,
   TableRow,
   TableCell
-} from "@/components/tailgrids/table";
+} from "@/components/tailgrids/core/table";
 
 export default TablePreview = () => (
   <TableRoot>
@@ -94,7 +94,7 @@ import {
   TableHead,
   TableRow,
   TableCell
-} from "@/components/tailgrids/table";
+} from "@/components/tailgrids/core/table";
 
 export default function TableExample() {
   return (

--- a/apps/docs/content/components/table.mdx
+++ b/apps/docs/content/components/table.mdx
@@ -68,7 +68,7 @@ import {
   TableCell
 } from "@/components/tailgrids/core/table";
 
-export default TablePreview = () => (
+const TablePreview = () => (
   <TableRoot>
     <TableHeader>
       <TableRow>
@@ -82,6 +82,8 @@ export default TablePreview = () => (
     </TableBody>
   </TableRoot>
 );
+
+export default TablePreview;
 ```
 
 ## Usage

--- a/apps/docs/content/components/tabs.mdx
+++ b/apps/docs/content/components/tabs.mdx
@@ -73,7 +73,7 @@ import {
   TabContent
 } from "@/components/tailgrids/core/tabs";
 
-export default TabsExample = () => (
+const TabsExample = () => (
   <TabRoot defaultValue="tab1">
     <TabList>
       <TabTrigger value="tab1" />
@@ -83,6 +83,8 @@ export default TabsExample = () => (
     <TabContent value="tab2" />
   </TabRoot>
 );
+
+export default TabsExample;
 ```
 
 ## Usage

--- a/apps/docs/content/components/tabs.mdx
+++ b/apps/docs/content/components/tabs.mdx
@@ -66,7 +66,12 @@ Copy and paste the following component code into your project. Make sure you hav
 Import the tab parts and compose them to build the layout.
 
 ```tsx
-import { TabRoot, TabList, TabTrigger, TabContent } from "@/registry/core/tabs";
+import {
+  TabRoot,
+  TabList,
+  TabTrigger,
+  TabContent
+} from "@/components/tailgrids/tabs";
 
 export default TabsExample = () => (
   <TabRoot defaultValue="tab1">
@@ -85,7 +90,12 @@ export default TabsExample = () => (
 Import the components and use the default variant to create a standard tabbed interface.
 
 ```tsx
-import { TabContent, TabList, TabRoot, TabTrigger } from "@/registry/core/tabs";
+import {
+  TabContent,
+  TabList,
+  TabRoot,
+  TabTrigger
+} from "@/components/tailgrids/tabs";
 
 export default function TabsExample() {
   return (

--- a/apps/docs/content/components/tabs.mdx
+++ b/apps/docs/content/components/tabs.mdx
@@ -71,7 +71,7 @@ import {
   TabList,
   TabTrigger,
   TabContent
-} from "@/components/tailgrids/tabs";
+} from "@/components/tailgrids/core/tabs";
 
 export default TabsExample = () => (
   <TabRoot defaultValue="tab1">
@@ -95,7 +95,7 @@ import {
   TabList,
   TabRoot,
   TabTrigger
-} from "@/components/tailgrids/tabs";
+} from "@/components/tailgrids/core/tabs";
 
 export default function TabsExample() {
   return (

--- a/apps/docs/content/components/text-area.mdx
+++ b/apps/docs/content/components/text-area.mdx
@@ -9,7 +9,7 @@ import TextAreaPreview from "@/components/preview/text-area/text-area-preview";
 import TextAreaSuccessPreview from "@/components/preview/text-area/text-area-success-preview";
 import TextAreaWithHintPreview from "@/components/preview/text-area/text-area-with-hint-preview";
 import TextAreaWithLabelPreview from "@/components/preview/text-area/text-area-with-label-preview";
-import { TextArea } from "@/registry/core/text-area";
+import { TextArea } from "@/components/tailgrids/text-area";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -61,7 +61,7 @@ fileName="text-area.tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { TextArea } from "@/registry/core/text-area";
+import { TextArea } from "@/components/tailgrids/text-area";
 
 export default TextAreaExample = () => (
   <TextArea label="Message" placeholder="Write your message..." />

--- a/apps/docs/content/components/text-area.mdx
+++ b/apps/docs/content/components/text-area.mdx
@@ -9,7 +9,7 @@ import TextAreaPreview from "@/components/preview/text-area/text-area-preview";
 import TextAreaSuccessPreview from "@/components/preview/text-area/text-area-success-preview";
 import TextAreaWithHintPreview from "@/components/preview/text-area/text-area-with-hint-preview";
 import TextAreaWithLabelPreview from "@/components/preview/text-area/text-area-with-label-preview";
-import { TextArea } from "@/components/tailgrids/text-area";
+import { TextArea } from "@/registry/core/text-area";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -61,7 +61,7 @@ fileName="text-area.tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { TextArea } from "@/components/tailgrids/text-area";
+import { TextArea } from "@/components/tailgrids/core/text-area";
 
 export default TextAreaExample = () => (
   <TextArea label="Message" placeholder="Write your message..." />

--- a/apps/docs/content/components/time-field.mdx
+++ b/apps/docs/content/components/time-field.mdx
@@ -65,7 +65,7 @@ import {
   TimeFieldLabel,
   TimeFieldDescription,
   TimeFieldError
-} from "@/components/tailgrids/time-field";
+} from "@/components/tailgrids/core/time-field";
 
 export const TimeFieldExample = () => (
   <TimeField label="Meeting time">

--- a/apps/docs/content/components/time-field.mdx
+++ b/apps/docs/content/components/time-field.mdx
@@ -3,10 +3,10 @@ title: React Time Field Components
 description: A React time field component that allows users to select a time value. Used in forms to choose hours and minutes through an accessible time input.
 ---
 
-import TimeFieldPreview from "@/components/preview/time-field/time-field-preview";
 import TimeFieldBasicPreview from "@/components/preview/time-field/time-field-basic-preview";
-import TimeFieldUncontrolled from "@/components/preview/time-field/time-field-uncontrolled";
 import TimeFieldControlled from "@/components/preview/time-field/time-field-controlled";
+import TimeFieldPreview from "@/components/preview/time-field/time-field-preview";
+import TimeFieldUncontrolled from "@/components/preview/time-field/time-field-uncontrolled";
 import TimeFieldWithSeconds from "@/components/preview/time-field/time-field-with-seconds";
 import TimeFieldWithTimezone from "@/components/preview/time-field/time-field-with-timezone";
 import TimeFieldWithValidation from "@/components/preview/time-field/time-field-with-validation";
@@ -65,7 +65,7 @@ import {
   TimeFieldLabel,
   TimeFieldDescription,
   TimeFieldError
-} from "@/registry/core/time-field";
+} from "@/components/tailgrids/time-field";
 
 export const TimeFieldExample = () => (
   <TimeField label="Meeting time">
@@ -80,6 +80,7 @@ export const TimeFieldExample = () => (
 ## Examples
 
 ### Basic Usage
+
 A standard time field implementation using segments for precise time entry.
 
 <ComponentPreview
@@ -91,6 +92,7 @@ A standard time field implementation using segments for precise time entry.
 </ComponentPreview>
 
 ### Controlled
+
 Manage the time value externally using the `value` and `onChange` props.
 
 <ComponentPreview
@@ -102,6 +104,7 @@ Manage the time value externally using the `value` and `onChange` props.
 </ComponentPreview>
 
 ### Uncontrolled
+
 An uncontrolled time field with a `defaultValue` prop.
 
 <ComponentPreview
@@ -113,6 +116,7 @@ An uncontrolled time field with a `defaultValue` prop.
 </ComponentPreview>
 
 ### With Seconds
+
 Enable second selection by setting the `granularity` prop to `second`.
 
 <ComponentPreview
@@ -124,6 +128,7 @@ Enable second selection by setting the `granularity` prop to `second`.
 </ComponentPreview>
 
 ### With Timezone
+
 Display and manage time zones within the time field.
 
 <ComponentPreview
@@ -135,6 +140,7 @@ Display and manage time zones within the time field.
 </ComponentPreview>
 
 ### Validation
+
 Display error messages and validation states when the time value is invalid.
 
 <ComponentPreview
@@ -149,52 +155,50 @@ Display error messages and validation states when the time value is invalid.
 
 ### TimeField
 
-
 The segment-based time input component.
 
-| Prop | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `value` | `TimeValue` | - | The current value (controlled). |
-| `defaultValue` | `TimeValue` | - | The default value (uncontrolled). |
-| `onChange` | `(value: TimeValue) => void` | - | Handler that is called when the value changes. |
-| `label` | `string` | - | The content to display as the label. |
-| `description` | `string` | - | The content to display as the description. |
-| `errorMessage` | `string \| ((v: ValidationResult) => string)` | - | The content to display as the error message. |
-| `hourCycle` | `12 \| 24` | - | Whether to use 12 or 24 hour cycle. |
-| `granularity` | `'hour' \| 'minute' \| 'second'` | `'minute'` | The smallest unit of time to display. |
-| `hideTimeZone` | `boolean` | `false` | Whether to hide the time zone abbreviation. |
-| `minValue` | `TimeValue` | - | The minimum allowed time. |
-| `maxValue` | `TimeValue` | - | The maximum allowed time. |
-| `disabled` | `boolean` | `false` | Whether the input is disabled. |
-| `readOnly` | `boolean` | `false` | Whether the input is read only. |
-| `required` | `boolean` | `false` | Whether the input is required. |
-| `invalid` | `boolean` | `false` | Whether the input is shown in invalid state. |
-| `className` | `string` | - | Additional CSS classes to apply to the container. |
+| Prop           | Type                                          | Default    | Description                                       |
+| :------------- | :-------------------------------------------- | :--------- | :------------------------------------------------ |
+| `value`        | `TimeValue`                                   | -          | The current value (controlled).                   |
+| `defaultValue` | `TimeValue`                                   | -          | The default value (uncontrolled).                 |
+| `onChange`     | `(value: TimeValue) => void`                  | -          | Handler that is called when the value changes.    |
+| `label`        | `string`                                      | -          | The content to display as the label.              |
+| `description`  | `string`                                      | -          | The content to display as the description.        |
+| `errorMessage` | `string \| ((v: ValidationResult) => string)` | -          | The content to display as the error message.      |
+| `hourCycle`    | `12 \| 24`                                    | -          | Whether to use 12 or 24 hour cycle.               |
+| `granularity`  | `'hour' \| 'minute' \| 'second'`              | `'minute'` | The smallest unit of time to display.             |
+| `hideTimeZone` | `boolean`                                     | `false`    | Whether to hide the time zone abbreviation.       |
+| `minValue`     | `TimeValue`                                   | -          | The minimum allowed time.                         |
+| `maxValue`     | `TimeValue`                                   | -          | The maximum allowed time.                         |
+| `disabled`     | `boolean`                                     | `false`    | Whether the input is disabled.                    |
+| `readOnly`     | `boolean`                                     | `false`    | Whether the input is read only.                   |
+| `required`     | `boolean`                                     | `false`    | Whether the input is required.                    |
+| `invalid`      | `boolean`                                     | `false`    | Whether the input is shown in invalid state.      |
+| `className`    | `string`                                      | -          | Additional CSS classes to apply to the container. |
 
 ### TimeFieldLabel
 
-| Prop | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `className` | `string` | - | Additional CSS classes to apply to the label. |
+| Prop        | Type     | Default | Description                                   |
+| :---------- | :------- | :------ | :-------------------------------------------- |
+| `className` | `string` | -       | Additional CSS classes to apply to the label. |
 
 ### TimeFieldInput
 
-| Prop | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `className` | `string` | - | Additional CSS classes to apply to the input container. |
+| Prop        | Type     | Default | Description                                             |
+| :---------- | :------- | :------ | :------------------------------------------------------ |
+| `className` | `string` | -       | Additional CSS classes to apply to the input container. |
 
 ### TimeFieldDescription
 
-| Prop | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `className` | `string` | - | Additional CSS classes to apply to the description. |
+| Prop        | Type     | Default | Description                                         |
+| :---------- | :------- | :------ | :-------------------------------------------------- |
+| `className` | `string` | -       | Additional CSS classes to apply to the description. |
 
 ### TimeFieldError
 
-| Prop | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `className` | `string` | - | Additional CSS classes to apply to the error message. |
-
+| Prop        | Type     | Default | Description                                           |
+| :---------- | :------- | :------ | :---------------------------------------------------- |
+| `className` | `string` | -       | Additional CSS classes to apply to the error message. |
 
 ## Accessibility
 

--- a/apps/docs/content/components/time-picker.mdx
+++ b/apps/docs/content/components/time-picker.mdx
@@ -62,7 +62,7 @@ Import the component and pass the required props.
 import {
   TimePicker,
   TimePickerTrigger
-} from "@/components/tailgrids/time-picker";
+} from "@/components/tailgrids/core/time-picker";
 
 export const TimePickerExample = () => (
   <TimePicker onSelect={date => console.log(date)}>

--- a/apps/docs/content/components/time-picker.mdx
+++ b/apps/docs/content/components/time-picker.mdx
@@ -3,9 +3,9 @@ title: React Time Picker Components
 description: A React time picker component that allows users to select a time value. Used in forms to choose hours and minutes through an accessible time input.
 ---
 
-import TimePickerPreview from "@/components/preview/time-picker/time-picker-preview";
-import TimePickerLabelPreview from "@/components/preview/time-picker/time-picker-label-preview";
 import TimePickerCustomTriggerPreview from "@/components/preview/time-picker/time-picker-custom-trigger-preview";
+import TimePickerLabelPreview from "@/components/preview/time-picker/time-picker-label-preview";
+import TimePickerPreview from "@/components/preview/time-picker/time-picker-preview";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -59,7 +59,10 @@ Copy and paste the component code into your project.
 Import the component and pass the required props.
 
 ```tsx
-import { TimePicker, TimePickerTrigger } from "@/registry/core/time-picker";
+import {
+  TimePicker,
+  TimePickerTrigger
+} from "@/components/tailgrids/time-picker";
 
 export const TimePickerExample = () => (
   <TimePicker onSelect={date => console.log(date)}>

--- a/apps/docs/content/components/toast.mdx
+++ b/apps/docs/content/components/toast.mdx
@@ -8,7 +8,7 @@ import ToastPreview from "@/components/preview/toast/toast-preview";
 import ToastVariantsPreview from "@/components/preview/toast/toast-variants-preview";
 import ToastWithTitlePreview from "@/components/preview/toast/toast-with-title-preview";
 import ToastWithUndoPreview from "@/components/preview/toast/toast-with-undo-preview";
-import { AvatarToast, Toast } from "@/components/tailgrids/toast";
+import { AvatarToast, Toast } from "@/registry/core/toast";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -67,7 +67,7 @@ fileName="avatar.tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Toast, AvatarToast } from "@/components/tailgrids/toast";
+import { Toast, AvatarToast } from "@/components/tailgrids/core/toast";
 
 export const ToastExample = () => (
   <Toast

--- a/apps/docs/content/components/toast.mdx
+++ b/apps/docs/content/components/toast.mdx
@@ -8,7 +8,7 @@ import ToastPreview from "@/components/preview/toast/toast-preview";
 import ToastVariantsPreview from "@/components/preview/toast/toast-variants-preview";
 import ToastWithTitlePreview from "@/components/preview/toast/toast-with-title-preview";
 import ToastWithUndoPreview from "@/components/preview/toast/toast-with-undo-preview";
-import { AvatarToast, Toast } from "@/registry/core/toast";
+import { AvatarToast, Toast } from "@/components/tailgrids/toast";
 import { getFileContent } from "@/utils/get-file-content";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
@@ -67,7 +67,7 @@ fileName="avatar.tsx"
 Import the component and pass the required props.
 
 ```tsx
-import { Toast, AvatarToast } from "@/registry/core/toast";
+import { Toast, AvatarToast } from "@/components/tailgrids/toast";
 
 export const ToastExample = () => (
   <Toast

--- a/apps/docs/content/components/toggle.mdx
+++ b/apps/docs/content/components/toggle.mdx
@@ -51,7 +51,7 @@ fileName="toggle.tsx"
 ## Usage
 
 ```tsx
-import { Toggle } from "@/components/tailgrids/toggle";
+import { Toggle } from "@/components/tailgrids/core/toggle";
 
 export default function ToggleBasic() {
   return <Toggle label="Enable Feature X" defaultChecked />;

--- a/apps/docs/content/components/toggle.mdx
+++ b/apps/docs/content/components/toggle.mdx
@@ -51,7 +51,7 @@ fileName="toggle.tsx"
 ## Usage
 
 ```tsx
-import { Toggle } from "@/registry/core/toggle";
+import { Toggle } from "@/components/tailgrids/toggle";
 
 export default function ToggleBasic() {
   return <Toggle label="Enable Feature X" defaultChecked />;

--- a/apps/docs/content/components/tooltip.mdx
+++ b/apps/docs/content/components/tooltip.mdx
@@ -64,7 +64,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent
-} from "@/registry/core/tooltip";
+} from "@/components/tailgrids/tooltip";
 import { InfoCircle } from "@tailgrids/icons";
 
 export default function TooltipUsageExample() {

--- a/apps/docs/content/components/tooltip.mdx
+++ b/apps/docs/content/components/tooltip.mdx
@@ -64,7 +64,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent
-} from "@/components/tailgrids/tooltip";
+} from "@/components/tailgrids/core/tooltip";
 import { InfoCircle } from "@tailgrids/icons";
 
 export default function TooltipUsageExample() {


### PR DESCRIPTION
This pull request updates the documentation code examples for several UI components to import from the correct `@/components/tailgrids` path instead of the `@/registry/core` path. This ensures that all usage and import examples in the documentation reflect the expected structure.

**Component import path updates:**

* Updated all import statements for components to use the `@/components/tailgrids` path in their respective `.mdx` documentation files. 

These changes keep the documentation consistent with the expected component structure and prevent confusion for developers following the examples.